### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,17 +1,14 @@
 [
-{
-	"modid": "${modId}",
+  {
+    "modid": "${modId}",
     "name": "${modName}",
-	"description": "Adds additional wood styles from various mods including ExtraBiomesXL, Highlands, Thaumcraft, and Witchery.",
-	"version": "${modVersion}",
+    "description": "Adds additional wood styles from various mods including ExtraBiomesXL, Highlands, Thaumcraft, and Witchery.",
+    "version": "${modVersion}",
     "mcversion": "${minecraftVersion}",
-	"credits": "By jaquadro",
-	"logoFile": "",
-	"url": "http://www.jaquadro.com/",
-	"authorList": [ "jaquadro" ],
-	"parent": "StorageDrawers",
-	"requiredMods": [ "Forge", "StorageDrawers" ],
-	"dependencies": [ "StorageDrawers" ],
-	"useDependencyInformation": true
-}
+    "credits": "By jaquadro",
+    "logoFile": "",
+    "url": "http://www.jaquadro.com/",
+    "authorList": [ "jaquadro" ],
+    "parent": "StorageDrawers"
+  }
 ]


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.